### PR TITLE
fix: use `className` property for class

### DIFF
--- a/src/stampino.ts
+++ b/src/stampino.ts
@@ -226,8 +226,9 @@ export function renderNode(
           if (attributeHandler && attributeHandler.matches(attr.name)) {
             handledAttributes.push(attr);
           } else {
+            const propertyName = attr.name === 'class' ? 'className' : attr.name;
             // TODO: if attribute is a literal, add it to statics instead
-            propertyValuePairs.push(attr.name);
+            propertyValuePairs.push(propertyName);
             propertyValuePairs.push(getValue(attr, model));
           }
         }


### PR DESCRIPTION
## What I did

hard-code handling of `class` attr => `className` DOM property. being as this is an *a priori* special case, I felt it warranted this kind of solution rather than as a 'default attribute handler'
 
fixes #7

